### PR TITLE
yajl_tree_parse_read should return correct place of error where it happened

### DIFF
--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -496,12 +496,17 @@ yajl_val yajl_tree_parse_read(void (*pCallbackFn)(ytprc_t *), ytprc_t *pYtprc,
 		}
 	}
 
+	// In error case it keeps place where error was found.
+	size_t error_offset = yajl_get_bytes_consumed(handle);
+
 	status = yajl_complete_parse (handle);
 	if (status != yajl_status_ok)
 	{
 		if (error_buffer != NULL && error_buffer_size > 0)
-		{	char * internal_err_str = (char *) yajl_get_error(handle, 1, pYtprc->buffer, strlen((char *)pYtprc->buffer));
-
+		{
+			// Restore place where error was found.
+			handle->bytesConsumed = error_offset;
+			char * internal_err_str = (char *) yajl_get_error(handle, 1, pYtprc->buffer, strlen((char *) pYtprc->buffer));
 			snprintf(error_buffer, error_buffer_size, "%s", internal_err_str);
 			YA_FREE(&(handle->alloc), internal_err_str);
 		}


### PR DESCRIPTION
**Issue**: _yajl_tree_parse_ and _yajl_tree_parse_file_ return incorrect place of error if it happened.
**Reason**: According to current implementation, error points out to start of buffer or start of file latest chunk, because _yajl_complete_parse_ clears previous error place.
**Solution**: Keep place of error and recovering it before getting error description.
